### PR TITLE
This update allows the ref-x, ref-y, ref-width, and ref-height to have t...

### DIFF
--- a/src/joint.dia.element.js
+++ b/src/joint.dia.element.js
@@ -313,17 +313,17 @@ joint.dia.ElementView = joint.dia.CellView.extend({
 
         var ref = elAttrs['ref'];
         var refX = parseFloat(elAttrs['ref-x']);
-        var refXMult = _.isString(elAttrs['ref-x']) ? (elAttrs['ref-x'][elAttrs['ref-x']-1] === 'x') : false;
+        var refXMult = _.isString(elAttrs['ref-x']) ? (elAttrs['ref-x'][elAttrs['ref-x'].length-1] === 'x') : false;
         var refY = parseFloat(elAttrs['ref-y']);
-        var refYMult = _.isString(elAttrs['ref-y']) ? (elAttrs['ref-y'][elAttrs['ref-y']-1] === 'x') : false;
+        var refYMult = _.isString(elAttrs['ref-y']) ? (elAttrs['ref-y'][elAttrs['ref-y'].length-1] === 'x') : false;
         var refDx = parseFloat(elAttrs['ref-dx']);
         var refDy = parseFloat(elAttrs['ref-dy']);
         var yAlignment = elAttrs['y-alignment'];
         var xAlignment = elAttrs['x-alignment'];
         var refWidth = parseFloat(elAttrs['ref-width']);
-        var refWidthMult = _.isString(elAttrs['ref-width']) ? (elAttrs['ref-width'][elAttrs['ref-width']-1] === 'x') : false;
+        var refWidthMult = _.isString(elAttrs['ref-width']) ? (elAttrs['ref-width'][elAttrs['ref-width'].length-1] === 'x') : false;
         var refHeight = parseFloat(elAttrs['ref-height']);
-        var refHeightMult = _.isString(elAttrs['ref-height']) ? (elAttrs['ref-height'][elAttrs['ref-height']-1] === 'x') : false;
+        var refHeightMult = _.isString(elAttrs['ref-height']) ? (elAttrs['ref-height'][elAttrs['ref-height'].length-1] === 'x') : false;
 
         // `ref` is the selector of the reference element. If no `ref` is passed, reference
         // element is the root element.

--- a/src/joint.dia.element.js
+++ b/src/joint.dia.element.js
@@ -313,13 +313,17 @@ joint.dia.ElementView = joint.dia.CellView.extend({
 
         var ref = elAttrs['ref'];
         var refX = parseFloat(elAttrs['ref-x']);
+        var refXMult = _.isString(elAttrs['ref-x']) ? (elAttrs['ref-x'][elAttrs['ref-x']-1] === 'x') : false;
         var refY = parseFloat(elAttrs['ref-y']);
+        var refYMult = _.isString(elAttrs['ref-y']) ? (elAttrs['ref-y'][elAttrs['ref-y']-1] === 'x') : false;
         var refDx = parseFloat(elAttrs['ref-dx']);
         var refDy = parseFloat(elAttrs['ref-dy']);
         var yAlignment = elAttrs['y-alignment'];
         var xAlignment = elAttrs['x-alignment'];
         var refWidth = parseFloat(elAttrs['ref-width']);
+        var refWidthMult = _.isString(elAttrs['ref-width']) ? (elAttrs['ref-width'][elAttrs['ref-width']-1] === 'x') : false;
         var refHeight = parseFloat(elAttrs['ref-height']);
+        var refHeightMult = _.isString(elAttrs['ref-height']) ? (elAttrs['ref-height'][elAttrs['ref-height']-1] === 'x') : false;
 
         // `ref` is the selector of the reference element. If no `ref` is passed, reference
         // element is the root element.
@@ -356,7 +360,7 @@ joint.dia.ElementView = joint.dia.CellView.extend({
 
         if (isDefined(refWidth)) {
 
-            if (refWidth >= 0 && refWidth <= 1) {
+            if (refWidthMult || (refWidth >= 0 && refWidth <= 1)) {
 
                 vel.attr('width', refWidth * bbox.width);
 
@@ -368,7 +372,7 @@ joint.dia.ElementView = joint.dia.CellView.extend({
 
         if (isDefined(refHeight)) {
 
-            if (refHeight >= 0 && refHeight <= 1) {
+            if (refHeightMult || (refHeight >= 0 && refHeight <= 1)) {
 
                 vel.attr('height', refHeight * bbox.height);
 
@@ -412,7 +416,7 @@ joint.dia.ElementView = joint.dia.CellView.extend({
         // Analogical rules apply for `refY`.
         if (isDefined(refX)) {
 
-            if (refX > 0 && refX < 1) {
+            if (refXMult || (refX > 0 && refX < 1)) {
 
                 tx = bbox.x + bbox.width * refX;
 
@@ -429,7 +433,7 @@ joint.dia.ElementView = joint.dia.CellView.extend({
         }
         if (isDefined(refY)) {
 
-            if (refY > 0 && refY < 1) {
+            if (refYMult || (refY > 0 && refY < 1)) {
                 
                 ty = bbox.y + bbox.height * refY;
                 


### PR DESCRIPTION
...he format "x".   Currently if the value you supply is between 0 and 1, then it will be a multiple of the width/height of the ref target, meaning we can only multiply by a number less than one.  If you want to make something's width twice the width of it's ref target, you can't.  This allows you to specify a number followed by "x" to force that number to be a multiplier, so for example ref-width: '3x' would make the element 3 times the width of the ref target.  This change is fully backward compatible.