### PR TITLE
Fixed issue with FF 36+

### DIFF
--- a/src/joint.dia.link.js
+++ b/src/joint.dia.link.js
@@ -1042,7 +1042,7 @@ joint.dia.LinkView = joint.dia.CellView.extend({
 
     getPointAtLength: function(length) {
 
-        return this._V.connection.node.getPointAtLength(length);
+        return this._V.connection.node.getPointAtLength(length || 0);
     },
 
     // Interaction. The controller part.


### PR DESCRIPTION
Firefox can crash on rendering of tools when the length of links is not known yet.